### PR TITLE
READY: remove pg in development ENV

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,6 @@ end
 gem 'jquery-rails'
 
 group :test, :development do
-  gem 'pg'
   gem 'selenium-webdriver'
   gem 'database_cleaner'
   gem 'factory_girl_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,7 +190,6 @@ GEM
     nokogiri (1.6.0)
       mini_portile (~> 0.5.0)
     parallel (0.6.2)
-    pg (0.15.1)
     poltergeist (1.3.0)
       capybara (~> 2.1.0)
       faye-websocket (>= 0.4.4, < 0.5.0)
@@ -334,7 +333,6 @@ DEPENDENCIES
   metric_fu
   multimap
   mysql2
-  pg
   poltergeist
   rails (= 3.2.12)
   reek

--- a/config/capistrano_database_yml.rb
+++ b/config/capistrano_database_yml.rb
@@ -95,7 +95,7 @@ Capistrano::Configuration.instance.load do
           base: &base
             adapter: mysql2
             encoding: utf8
-            hostname: rdsjabziajabzia.mysql.rds.aliyuncs.com
+            host: rdsjabziajabzia.mysql.rds.aliyuncs.com
             username: #{Capistrano::CLI.ui.ask("Enter database username: ")}
             password: #{Capistrano::CLI.password_prompt("Enter database password: ")}
             pool: 5

--- a/config/database.yml.template
+++ b/config/database.yml.template
@@ -1,24 +1,17 @@
-# PostgreSQL. Versions 8.2 and up are supported.
+# MySQL. Versions 5.5 supported.
 #
-# Install the pg driver:
-#   gem install pg
-# On Mac OS X with macports:
-#   gem install pg -- --with-pg-config=/opt/local/lib/postgresql84/bin/pg_config
-# On Windows:
-#   gem install pg
-#       Choose the win32 build.
-#       Install PostgreSQL and put its /bin directory on your path.
+# Install the mysql driver:
 #
 # Configure Using Gemfile
-# gem 'pg'
+# gem 'mysql2'
 #
 development:
   host: localhost
-  adapter: postgresql
-  encoding: unicode
+  adapter: mysql2
+  encoding: utf8
   database: lohaswork_development
   pool: 5
-  username: change_to_your_name 
+  username: change_to_your_name
   password: change_to_your_password
 
   # Connect on a TCP socket. Omitted by default since the client uses a
@@ -41,18 +34,18 @@ development:
 # Do not set this db to the same as development or production.
 test:
   host: localhost
-  adapter: postgresql
-  encoding: unicode
+  adapter: mysql2
+  encoding: utf8
   database: lohaswork_test
   pool: 5
-  username: change_to_your_name 
+  username: change_to_your_name
   password: change_to_your_password
 
 production:
   host: localhost
-  adapter: postgresql
-  encoding: unicode
+  adapter: mysql2
+  encoding: utf8
   database: lohaswork_production
   pool: 5
-  username: change_to_your_name 
+  username: change_to_your_name
   password: change_to_your_password


### PR DESCRIPTION
开发环境迁移至mysql

Mac 童鞋
[猛戳这里下载5.5.33的64-bit dmg版本](http://dev.mysql.com/downloads/mysql/5.5.html#downloads)
- 安装包内两个pkg文件，前者为安装文件，后者MySQL Startup Item为自启动文件，可酌情选择安装
- 安装自启动脚本后，启动mysql服务

```
sudo /Library/StartupItems/MySQLCOM/MySQLCOM start 
```
- 不安装自启动脚本，启动mysql服务

```
cd /usr/local/mysql
sudo ./bin/mysqld_safe
```
- 设置root用户密码

```
/usr/local/mysql/bin/mysqladmin -u root password NEW_PASSWORD_HERE
```
- 配置一个mysql用户

```
mysql -uroot -p
mysql> CREATE USER 'yourusername'@'localhost' IDENTIFIED BY 'yourpassword';
mysql> GRANT ALL PRIVILEGES ON *.* TO 'yourusername'@'localhost' WITH GRANT OPTION;
mysql> \q
```

Linux 童鞋

```
sudo apt-get install mysql-server-5.5 mysql-client-5.5
mysql -uroot -p
mysql> CREATE USER 'yourusername'@'localhost' IDENTIFIED BY 'yourpassword';
mysql> GRANT ALL PRIVILEGES ON *.* TO 'yourusername'@'localhost' WITH GRANT OPTION;
mysql> \q
```

当然各位不要忘了本地的 

```
cp config/database.yml.template config/database.yml  //记得修改用户名密码
rake db:create:all
rake db:migrate
rake db:test:prepare
```
