### PR TITLE
READY: Send email or not is configurable

### DIFF
--- a/config/config.rb
+++ b/config/config.rb
@@ -1,10 +1,11 @@
 {
   default:{
       mailgun_api_key: "key-16qe6sz-8wtgabba2ei96pcb89823q65",
-      recieve_test_email:"test@lohaswork.com"
+      recieve_test_email:"test@lohaswork.com",
+      email: true
     },
   test:{
-
+    email: false
   },
   development:{
 

--- a/lib/email_engine/mailgun_gateway.rb
+++ b/lib/email_engine/mailgun_gateway.rb
@@ -11,10 +11,14 @@ module EmailEngine
           to: delivery_filter(options[:to]),
           subject: options[:subject],
           html: options[:body]
-          ) if !Rails.env.test?
+          ) if send_email?
     end
 
     private
+
+    def send_email?
+      !!$config.email
+    end
 
     def default_sender
       "LohasWork <notice@charleschu.mailgun.org>"


### PR DESCRIPTION
Your can change the config email value in config/config.rb to control sending email or not. the default value is true, and you can override it in the env config hash of config.rb. (You should reboot the serve if already changed the config)
